### PR TITLE
feat: create and automate the overwhelm helmchart and add events

### DIFF
--- a/.charts/overwhelm/Chart.yaml
+++ b/.charts/overwhelm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: overwhelm
+version: 0.0.3
+maintainers:
+    - name: "Expedia Group"
+      url: "https://github.com/ExpediaGroup/overwhelm"

--- a/.charts/overwhelm/templates/applications.core.expediagroup.com-crd.yaml
+++ b/.charts/overwhelm/templates/applications.core.expediagroup.com-crd.yaml
@@ -1,0 +1,613 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: applications.core.expediagroup.com
+spec:
+  group: core.expediagroup.com
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    shortNames:
+    - app
+    singular: application
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is the Schema for the applications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSpec defines the desired state of Application
+            properties:
+              data:
+                additionalProperties:
+                  type: string
+                description: Data to be consolidated for the Helm Chart's values.yaml file
+                type: object
+              preRenderer:
+                description: PreRenderer holds custom templating delimiters and a flag to By default standard delimiters \{\{ and }} will be used to render values within. If specified then the custom delimiters will be used.
+                properties:
+                  closeDelimiter:
+                    description: Custom non white-spaced and non alpha-numeric close delimiter used for go templating action to pre-render. For e.g., %>. Default is  }}
+                    maxLength: 2
+                    minLength: 2
+                    type: string
+                  enableHelmTemplating:
+                    description: Enable to allow Helm Templating to interpolate values within the default delimiters \{\{ }}. Defaults to false allowing the pre-renderer to do interpolation within the default delimiters. If both helm templating and pre-rendering are desired, then enable EnableHelmTemplating and specify custom delimiters as LeftDelimiter and RightDelimiter
+                    type: boolean
+                  openDelimiter:
+                    description: Custom non white-spaced and non alpha-numeric open delimiter used for go templating action to pre-render. For e.g., <%. Default is \{\{
+                    maxLength: 2
+                    minLength: 2
+                    type: string
+                type: object
+              template:
+                description: Template of Release metadata and spec needed for the resources created by the Application Controller
+                properties:
+                  metadata:
+                    description: Metadata to be applied to the resources created by the Application Controller
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec to be applied to the Helm Release resource created by the Application Controller
+                    properties:
+                      chart:
+                        description: Chart defines the template of the v1beta2.HelmChart that should be created for this HelmRelease.
+                        properties:
+                          spec:
+                            description: Spec holds the template for the v1beta2.HelmChartSpec for this HelmRelease.
+                            properties:
+                              chart:
+                                description: The name or path the Helm chart is available at in the SourceRef.
+                                type: string
+                              interval:
+                                description: Interval at which to check the v1beta2.Source for updates. Defaults to 'HelmReleaseSpec.Interval'.
+                                type: string
+                              reconcileStrategy:
+                                default: ChartVersion
+                                description: Determines what enables the creation of a new artifact. Valid values are ('ChartVersion', 'Revision'). See the documentation of the values for an explanation on their behavior. Defaults to ChartVersion when omitted.
+                                enum:
+                                - ChartVersion
+                                - Revision
+                                type: string
+                              sourceRef:
+                                description: The name and namespace of the v1beta2.Source the chart is available at.
+                                properties:
+                                  apiVersion:
+                                    description: APIVersion of the referent.
+                                    type: string
+                                  kind:
+                                    description: Kind of the referent.
+                                    enum:
+                                    - HelmRepository
+                                    - GitRepository
+                                    - Bucket
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent.
+                                    maxLength: 63
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              valuesFile:
+                                description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file defined here is merged before the ValuesFiles items. Ignored when omitted.
+                                type: string
+                              valuesFiles:
+                                description: Alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
+                                items:
+                                  type: string
+                                type: array
+                              version:
+                                default: '*'
+                                description: Version semver expression, ignored for charts from v1beta2.GitRepository and v1beta2.Bucket sources. Defaults to latest when omitted.
+                                type: string
+                            required:
+                            - chart
+                            - sourceRef
+                            type: object
+                        required:
+                        - spec
+                        type: object
+                      dependsOn:
+                        description: DependsOn may contain a meta.NamespacedObjectReference slice with references to HelmRelease resources that must be ready before this HelmRelease can be reconciled.
+                        items:
+                          description: NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any namespace.
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                            namespace:
+                              description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      install:
+                        description: Install holds the configuration for Helm install actions for this HelmRelease.
+                        properties:
+                          crds:
+                            description: "CRDs upgrade CRDs from the Helm Chart's crds directory according to the CRD upgrade policy provided here. Valid values are `Skip`, `Create` or `CreateReplace`. Default is `Create` and if omitted CRDs are installed but not updated. \n Skip: do neither install nor replace (update) any CRDs. \n Create: new CRDs are created, existing CRDs are neither updated nor deleted. \n CreateReplace: new CRDs are created, existing CRDs are updated (replaced) but not deleted. \n By default, CRDs are applied (installed) during Helm install action. With this option users can opt-in to CRD replace existing CRDs on Helm install actions, which is not (yet) natively supported by Helm. https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                            enum:
+                            - Skip
+                            - Create
+                            - CreateReplace
+                            type: string
+                          createNamespace:
+                            description: CreateNamespace tells the Helm install action to create the HelmReleaseSpec.TargetNamespace if it does not exist yet. On uninstall, the namespace will not be garbage collected.
+                            type: boolean
+                          disableHooks:
+                            description: DisableHooks prevents hooks from running during the Helm install action.
+                            type: boolean
+                          disableOpenAPIValidation:
+                            description: DisableOpenAPIValidation prevents the Helm install action from validating rendered templates against the Kubernetes OpenAPI Schema.
+                            type: boolean
+                          disableWait:
+                            description: DisableWait disables the waiting for resources to be ready after a Helm install has been performed.
+                            type: boolean
+                          disableWaitForJobs:
+                            description: DisableWaitForJobs disables waiting for jobs to complete after a Helm install has been performed.
+                            type: boolean
+                          remediation:
+                            description: Remediation holds the remediation configuration for when the Helm install action for the HelmRelease fails. The default is to not perform any action.
+                            properties:
+                              ignoreTestFailures:
+                                description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an install action but fail. Defaults to 'Test.IgnoreFailures'.
+                                type: boolean
+                              remediateLastFailure:
+                                description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false'.
+                                type: boolean
+                              retries:
+                                description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using an uninstall, is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
+                                type: integer
+                            type: object
+                          replace:
+                            description: Replace tells the Helm install action to re-use the 'ReleaseName', but only if that name is a deleted release which remains in the history.
+                            type: boolean
+                          skipCRDs:
+                            description: "SkipCRDs tells the Helm install action to not install any CRDs. By default, CRDs are installed if not already present. \n Deprecated use CRD policy (`crds`) attribute with value `Skip` instead."
+                            type: boolean
+                          timeout:
+                            description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
+                            type: string
+                        type: object
+                      interval:
+                        description: Interval at which to reconcile the Helm release.
+                        type: string
+                      kubeConfig:
+                        description: KubeConfig for reconciling the HelmRelease on a remote cluster. When used in combination with HelmReleaseSpec.ServiceAccountName, forces the controller to act on behalf of that Service Account at the target cluster. If the --default-service-account flag is set, its value will be used as a controller level fallback for when HelmReleaseSpec.ServiceAccountName is empty.
+                        properties:
+                          secretRef:
+                            description: SecretRef holds the name to a secret that contains a key with the kubeconfig file as the value. If no key is specified the key will default to 'value'. The secret must be in the same namespace as the HelmRelease. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the HelmRelease.
+                            properties:
+                              key:
+                                description: Key in the Secret, when not specified an implementation-specific default key is used.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      maxHistory:
+                        description: MaxHistory is the number of revisions saved by Helm for this HelmRelease. Use '0' for an unlimited number of revisions; defaults to '10'.
+                        type: integer
+                      postRenderers:
+                        description: PostRenderers holds an array of Helm PostRenderers, which will be applied in order of their definition.
+                        items:
+                          description: PostRenderer contains a Helm PostRenderer specification.
+                          properties:
+                            kustomize:
+                              description: Kustomization to apply as PostRenderer.
+                              properties:
+                                images:
+                                  description: Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.
+                                  items:
+                                    description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                                    properties:
+                                      digest:
+                                        description: Digest is the value used to replace the original image tag. If digest is present NewTag value is ignored.
+                                        type: string
+                                      name:
+                                        description: Name is a tag-less image name.
+                                        type: string
+                                      newName:
+                                        description: NewName is the value used to replace the original name.
+                                        type: string
+                                      newTag:
+                                        description: NewTag is the value used to replace the original tag.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                patches:
+                                  description: Strategic merge and JSON patches, defined as inline YAML objects, capable of targeting objects based on kind, label and annotation selectors.
+                                  items:
+                                    description: Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should be applied to.
+                                    properties:
+                                      patch:
+                                        description: Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with an array of operation objects.
+                                        type: string
+                                      target:
+                                        description: Target points to the resources that the patch document should be applied to.
+                                        properties:
+                                          annotationSelector:
+                                            description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                                            type: string
+                                          group:
+                                            description: Group is the API group to select resources from. Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                          kind:
+                                            description: Kind of the API Group to select resources from. Together with Group and Version it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                          labelSelector:
+                                            description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                                            type: string
+                                          name:
+                                            description: Name to match resources with.
+                                            type: string
+                                          namespace:
+                                            description: Namespace to select resources from.
+                                            type: string
+                                          version:
+                                            description: Version of the API Group to select resources from. Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                                patchesJson6902:
+                                  description: JSON 6902 patches, defined as inline YAML objects.
+                                  items:
+                                    description: JSON6902Patch contains a JSON6902 patch and the target the patch should be applied to.
+                                    properties:
+                                      patch:
+                                        description: Patch contains the JSON6902 patch document with an array of operation objects.
+                                        items:
+                                          description: JSON6902 is a JSON6902 operation object. https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                          properties:
+                                            from:
+                                              description: From contains a JSON-pointer value that references a location within the target document where the operation is performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                              type: string
+                                            op:
+                                              description: Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or "test". https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                              enum:
+                                              - test
+                                              - remove
+                                              - add
+                                              - replace
+                                              - move
+                                              - copy
+                                              type: string
+                                            path:
+                                              description: Path contains the JSON-pointer value that references a location within the target document where the operation is performed. The meaning of the value depends on the value of Op.
+                                              type: string
+                                            value:
+                                              description: Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          required:
+                                          - op
+                                          - path
+                                          type: object
+                                        type: array
+                                      target:
+                                        description: Target points to the resources that the patch document should be applied to.
+                                        properties:
+                                          annotationSelector:
+                                            description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                                            type: string
+                                          group:
+                                            description: Group is the API group to select resources from. Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                          kind:
+                                            description: Kind of the API Group to select resources from. Together with Group and Version it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                          labelSelector:
+                                            description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                                            type: string
+                                          name:
+                                            description: Name to match resources with.
+                                            type: string
+                                          namespace:
+                                            description: Namespace to select resources from.
+                                            type: string
+                                          version:
+                                            description: Version of the API Group to select resources from. Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                            type: string
+                                        type: object
+                                    required:
+                                    - patch
+                                    - target
+                                    type: object
+                                  type: array
+                                patchesStrategicMerge:
+                                  description: Strategic merge patches, defined as inline YAML objects.
+                                  items:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      releaseName:
+                        description: ReleaseName used for the Helm release. Defaults to a composition of '[TargetNamespace-]Name'.
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                      rollback:
+                        description: Rollback holds the configuration for Helm rollback actions for this HelmRelease.
+                        properties:
+                          cleanupOnFail:
+                            description: CleanupOnFail allows deletion of new resources created during the Helm rollback action when it fails.
+                            type: boolean
+                          disableHooks:
+                            description: DisableHooks prevents hooks from running during the Helm rollback action.
+                            type: boolean
+                          disableWait:
+                            description: DisableWait disables the waiting for resources to be ready after a Helm rollback has been performed.
+                            type: boolean
+                          disableWaitForJobs:
+                            description: DisableWaitForJobs disables waiting for jobs to complete after a Helm rollback has been performed.
+                            type: boolean
+                          force:
+                            description: Force forces resource updates through a replacement strategy.
+                            type: boolean
+                          recreate:
+                            description: Recreate performs pod restarts for the resource if applicable.
+                            type: boolean
+                          timeout:
+                            description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
+                            type: string
+                        type: object
+                      serviceAccountName:
+                        description: The name of the Kubernetes service account to impersonate when reconciling this HelmRelease.
+                        type: string
+                      storageNamespace:
+                        description: StorageNamespace used for the Helm storage. Defaults to the namespace of the HelmRelease.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      suspend:
+                        description: Suspend tells the controller to suspend reconciliation for this HelmRelease, it does not apply to already started reconciliations. Defaults to false.
+                        type: boolean
+                      targetNamespace:
+                        description: TargetNamespace to target when performing operations for the HelmRelease. Defaults to the namespace of the HelmRelease.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      test:
+                        description: Test holds the configuration for Helm test actions for this HelmRelease.
+                        properties:
+                          enable:
+                            description: Enable enables Helm test actions for this HelmRelease after an Helm install or upgrade action has been performed.
+                            type: boolean
+                          ignoreFailures:
+                            description: IgnoreFailures tells the controller to skip remediation when the Helm tests are run but fail. Can be overwritten for tests run after install or upgrade actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                            type: boolean
+                          timeout:
+                            description: Timeout is the time to wait for any individual Kubernetes operation during the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                            type: string
+                        type: object
+                      timeout:
+                        description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                        type: string
+                      uninstall:
+                        description: Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.
+                        properties:
+                          disableHooks:
+                            description: DisableHooks prevents hooks from running during the Helm rollback action.
+                            type: boolean
+                          disableWait:
+                            description: DisableWait disables waiting for all the resources to be deleted after a Helm uninstall is performed.
+                            type: boolean
+                          keepHistory:
+                            description: KeepHistory tells Helm to remove all associated resources and mark the release as deleted, but retain the release history.
+                            type: boolean
+                          timeout:
+                            description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
+                            type: string
+                        type: object
+                      upgrade:
+                        description: Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.
+                        properties:
+                          cleanupOnFail:
+                            description: CleanupOnFail allows deletion of new resources created during the Helm upgrade action when it fails.
+                            type: boolean
+                          crds:
+                            description: "CRDs upgrade CRDs from the Helm Chart's crds directory according to the CRD upgrade policy provided here. Valid values are `Skip`, `Create` or `CreateReplace`. Default is `Skip` and if omitted CRDs are neither installed nor upgraded. \n Skip: do neither install nor replace (update) any CRDs. \n Create: new CRDs are created, existing CRDs are neither updated nor deleted. \n CreateReplace: new CRDs are created, existing CRDs are updated (replaced) but not deleted. \n By default, CRDs are not applied during Helm upgrade action. With this option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm. https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                            enum:
+                            - Skip
+                            - Create
+                            - CreateReplace
+                            type: string
+                          disableHooks:
+                            description: DisableHooks prevents hooks from running during the Helm upgrade action.
+                            type: boolean
+                          disableOpenAPIValidation:
+                            description: DisableOpenAPIValidation prevents the Helm upgrade action from validating rendered templates against the Kubernetes OpenAPI Schema.
+                            type: boolean
+                          disableWait:
+                            description: DisableWait disables the waiting for resources to be ready after a Helm upgrade has been performed.
+                            type: boolean
+                          disableWaitForJobs:
+                            description: DisableWaitForJobs disables waiting for jobs to complete after a Helm upgrade has been performed.
+                            type: boolean
+                          force:
+                            description: Force forces resource updates through a replacement strategy.
+                            type: boolean
+                          preserveValues:
+                            description: PreserveValues will make Helm reuse the last release's values and merge in overrides from 'Values'. Setting this flag makes the HelmRelease non-declarative.
+                            type: boolean
+                          remediation:
+                            description: Remediation holds the remediation configuration for when the Helm upgrade action for the HelmRelease fails. The default is to not perform any action.
+                            properties:
+                              ignoreTestFailures:
+                                description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an upgrade action but fail. Defaults to 'Test.IgnoreFailures'.
+                                type: boolean
+                              remediateLastFailure:
+                                description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                                type: boolean
+                              retries:
+                                description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using 'Strategy', is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
+                                type: integer
+                              strategy:
+                                description: Strategy to use for failure remediation. Defaults to 'rollback'.
+                                enum:
+                                - rollback
+                                - uninstall
+                                type: string
+                            type: object
+                          timeout:
+                            description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
+                            type: string
+                        type: object
+                      values:
+                        description: Values holds the values for this Helm release.
+                        x-kubernetes-preserve-unknown-fields: true
+                      valuesFrom:
+                        description: ValuesFrom holds references to resources containing Helm values for this HelmRelease, and information about how they should be merged.
+                        items:
+                          description: ValuesReference contains a reference to a resource containing Helm values, and optionally the key they can be found at.
+                          properties:
+                            kind:
+                              description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
+                              enum:
+                              - Secret
+                              - ConfigMap
+                              type: string
+                            name:
+                              description: Name of the values referent. Should reside in the same namespace as the referring resource.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            optional:
+                              description: Optional marks this ValuesReference as optional. When set, a not found error for the values reference is ignored, but any ValuesKey, TargetPath or transient error will still result in a reconciliation failure.
+                              type: boolean
+                            targetPath:
+                              description: TargetPath is the YAML dot notation path the value should be merged at. When set, the ValuesKey is expected to be a single flat value. Defaults to 'None', which results in the values getting merged at the root.
+                              type: string
+                            valuesKey:
+                              description: ValuesKey is the data key where the values.yaml or a specific value can be found at. Defaults to 'values.yaml'.
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - chart
+                    - interval
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ApplicationStatus defines the observed state of Application
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the Application.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: Failures is the reconciliation failure count against the latest desired state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmReleaseResourceVersion:
+                description: HelmReleaseResourceVersion is the helm release resource version
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              valuesResourceVersion:
+                description: ValuesResourceVersion is the resource version of the resource that contains the helm values
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/.charts/overwhelm/templates/overwhelm-controller-manager-deployment.yaml
+++ b/.charts/overwhelm/templates/overwhelm-controller-manager-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system
+spec:
+  replicas: {{ .Values.overwhelm.deployment.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations: 
+{{ toYaml .Values.overwhelm.deployment.annotations  | indent 8 }}
+      labels: 
+{{ toYaml .Values.overwhelm.deployment.labels  | indent 8 }}
+    spec:
+      containers:
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: {{ .Values.overwhelm.deployment.image.manager.name }}:{{ .Values.overwhelm.deployment.image.manager.tag }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: 
+{{ toYaml .Values.overwhelm.deployment.resources  | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: {{ .Values.overwhelm.deployment.image.kubeRbacProxy.name }}:{{ .Values.overwhelm.deployment.image.kubeRbacProxy.tag }}
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: overwhelm-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/.charts/overwhelm/templates/overwhelm-controller-manager-metrics-service-svc.yaml
+++ b/.charts/overwhelm/templates/overwhelm-controller-manager-metrics-service-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: overwhelm-controller-manager-metrics-service
+  namespace: overwhelm-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/.charts/overwhelm/templates/overwhelm-controller-manager-sa.yaml
+++ b/.charts/overwhelm/templates/overwhelm-controller-manager-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system

--- a/.charts/overwhelm/templates/overwhelm-leader-election-role-role.yaml
+++ b/.charts/overwhelm/templates/overwhelm-leader-election-role-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: overwhelm-leader-election-role
+  namespace: overwhelm-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/.charts/overwhelm/templates/overwhelm-leader-election-rolebinding-rb.yaml
+++ b/.charts/overwhelm/templates/overwhelm-leader-election-rolebinding-rb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: overwhelm-leader-election-rolebinding
+  namespace: overwhelm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: overwhelm-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system

--- a/.charts/overwhelm/templates/overwhelm-manager-config-cm.yaml
+++ b/.charts/overwhelm/templates/overwhelm-manager-config-cm.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: e04e01ad.expediagroup.com
+kind: ConfigMap
+metadata:
+  name: overwhelm-manager-config
+  namespace: overwhelm-system

--- a/.charts/overwhelm/templates/overwhelm-manager-role-cr.yaml
+++ b/.charts/overwhelm/templates/overwhelm-manager-role-cr.yaml
@@ -1,0 +1,64 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: overwhelm-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.expediagroup.com
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.expediagroup.com
+  resources:
+  - applications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.expediagroup.com
+  resources:
+  - applications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - helm.toolkit.fluxcd.io
+  resources:
+  - helmreleases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - helm.toolkit.fluxcd.io
+  resources:
+  - helmreleases/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/.charts/overwhelm/templates/overwhelm-manager-rolebinding-crb.yaml
+++ b/.charts/overwhelm/templates/overwhelm-manager-rolebinding-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: overwhelm-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: overwhelm-manager-role
+subjects:
+- kind: ServiceAccount
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system

--- a/.charts/overwhelm/templates/overwhelm-metrics-reader-cr.yaml
+++ b/.charts/overwhelm/templates/overwhelm-metrics-reader-cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: overwhelm-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/.charts/overwhelm/templates/overwhelm-proxy-role-cr.yaml
+++ b/.charts/overwhelm/templates/overwhelm-proxy-role-cr.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: overwhelm-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/.charts/overwhelm/templates/overwhelm-proxy-rolebinding-crb.yaml
+++ b/.charts/overwhelm/templates/overwhelm-proxy-rolebinding-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: overwhelm-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: overwhelm-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system

--- a/.charts/overwhelm/templates/overwhelm-system-namespace.yaml
+++ b/.charts/overwhelm/templates/overwhelm-system-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: overwhelm-system

--- a/.charts/overwhelm/values.yaml
+++ b/.charts/overwhelm/values.yaml
@@ -1,0 +1,21 @@
+---
+overwhelm:
+  deployment:
+    image:
+      manager:
+        name: ghcr.io/expediagroup/overwhelm
+        tag: latest
+      kubeRbacProxy:
+        name: gcr.io/kubebuilder/kube-rbac-proxy
+        tag: v0.8.0
+    labels:
+      control-plane: controller-manager
+    replicas: 2
+    resources:
+      limits:
+        cpu: 1024m
+        memory: 1Gi
+      requests:
+        cpu: 128m
+        memory: 64Mi
+

--- a/.github/workflows/helm-chart-releaser.yaml
+++ b/.github/workflows/helm-chart-releaser.yaml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: .charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ PROJECT := overwhelm
 REGISTRY := ghcr.io/expediagroup
 VERSION := $(shell git rev-parse HEAD|| echo "v0.0.1") #may need to change this to tags if we are using tags
 IMG = $(REGISTRY)/$(PROJECT):$(VERSION)
+VALUES_BASED_PROJECT = "{{ .Values.deployment.image }}"
+VALUES_BASED_IMG = $(VALUES_BASED_PROJECT):$(VERSION)
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -140,6 +142,17 @@ endif
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
+.PHONY: helmManifests
+helmManifests: manifests kustomize kubernetes-split-yaml ## Create Helm Templates to deploy manifests using Helm
+	$(KUSTOMIZE) build config/helm-manifest >> .charts/tmp.yaml
+	go run scripts/helm-charts/update.go
+	$(KUBERNETES_SPLIT_YAML) --outdir .charts/overwhelm/templates .charts/tmp.yaml
+	rm .charts/tmp.yaml
+
+.PHONY: helmInstall
+helmInstall:
+	helm upgrade -i overwhelm ./.charts/overwhelm
+
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
@@ -149,6 +162,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -169,6 +183,16 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
+KUBERNETES_SPLIT_YAML = $(shell pwd)/bin/kubernetes-split-yaml
+.PHONY: kubernetes-split-yaml
+kubernetes-split-yaml: ## Download kustomize locally if necessary.
+	$(call go-get-tool,$(KUBERNETES_SPLIT_YAML),github.com/mogensen/kubernetes-split-yaml@latest)
+
+.PHONY: split-yaml
+split-yaml: kubernetes-split-yaml
+	$(KUBERNETES_SPLIT_YAML) --outdir .charts ./.charts/templates/x.yaml
+	rm ./.charts/templates/x.yaml
+
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
@@ -178,7 +202,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go get -d $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
@@ -257,11 +281,20 @@ kind-install-deps:
 kind-create-cluster:
 	kind create cluster --name overwhelm
 	flux install
-	kubectl create clusterrolebinding --serviceaccount=overwhelm-system:overwhelm-controller-manager --clusterrole=cluster-admin overwhelm-controller-manager
+	#kubectl create clusterrolebinding --serviceaccount=overwhelm-system:overwhelm-controller-manager --clusterrole=cluster-admin overwhelm-controller-manager
 
 .PHONY: kind-deploy
 kind-deploy: manifests kustomize deploy docker-build
 	kind load docker-image ${IMG} --name overwhelm
+
+.PHONY: kind-docker-load
+kind-docker-load: docker-build
+	kind load docker-image ${IMG} --name overwhelm
+
+.PHONY: kind-helm-debug
+kind-helm-debug: kind-docker-load helmManifests helmInstall
+	# After this, you can run overwhelm locally. Ignore the ImagePullBackOff from the overwhelm-controller-manager pod,
+	# just start overwhelm locally (i.e. via your IDE).
 
 .PHONY: kind-debug
 kind-debug: manifests kustomize deploy

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get -d $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ operator-sdk create api --group core --version v1alpha1 --kind Application --res
 - Deploy overwhelm by executing `make kind-deploy`
 - (optional) Install a dummy Application by executing `make kind-install-dummy-app`
 
+
 To clean the Kind cluster, execute `make kind-clean`.
+
+## Helm Charts
+- The .charts folder contains the `overwhelm` helm chart.
+- `make helmManifests` will update the chart templates if any changes are made to the helm resources. 
+- To debug using helm install of the resources execute `make kind-helm-debug` once you create a Kind cluster.
 
 
 ## Prerequisite

--- a/config/helm-manifest/kustomization.yaml
+++ b/config/helm-manifest/kustomization.yaml
@@ -1,0 +1,16 @@
+bases:
+  - ../default
+
+patchesStrategicMerge:
+  - manager_deployment_patch.yaml
+
+patchesJson6902: # We use Json6902 patches for inline replacement patches which are not possible with Strategic Merge patches
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: overwhelm-controller-manager
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value: <GOTEMPLATE> toYaml .Values.overwhelm.deployment.resources  | indent 10 </GOTEMPLATE>

--- a/config/helm-manifest/manager_deployment_patch.yaml
+++ b/config/helm-manifest/manager_deployment_patch.yaml
@@ -1,0 +1,19 @@
+# Use <GOTEMPLATE></GOTEMPLATE> tags for Go template delimiters to be inserted by the script/helm-charts/update.go script
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overwhelm-controller-manager
+  namespace: overwhelm-system
+spec:
+  replicas: <GOTEMPLATE> .Values.overwhelm.deployment.replicas </GOTEMPLATE>
+  template:
+    metadata:
+      $patch: replace
+      annotations: <GOTEMPLATE> toYaml .Values.overwhelm.deployment.annotations  | indent 8 </GOTEMPLATE>
+      labels: <GOTEMPLATE> toYaml .Values.overwhelm.deployment.labels  | indent 8 </GOTEMPLATE>
+    spec:
+      containers:
+      - name: manager
+        image: <GOTEMPLATE> .Values.overwhelm.deployment.image.manager.name </GOTEMPLATE>:<GOTEMPLATE> .Values.overwhelm.deployment.image.manager.tag </GOTEMPLATE>
+      - name: kube-rbac-proxy
+        image: <GOTEMPLATE> .Values.overwhelm.deployment.image.kubeRbacProxy.name </GOTEMPLATE>:<GOTEMPLATE> .Values.overwhelm.deployment.image.kubeRbacProxy.tag </GOTEMPLATE>

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,5 +10,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/expediagroup/overwhelm
-  newTag: ca5f8665f84592140deef86212ddd3f7e9ec4f73
+

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -84,6 +84,7 @@ var _ = BeforeSuite(func() {
 		Scheme:          k8sManager.GetScheme(),
 		RequeueInterval: 3 * time.Second,
 		Retries:         int64(3),
+		Events:          k8sManager.GetEventRecorderFor("overwhelm"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 	go func() {

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 		Scheme:          mgr.GetScheme(),
 		RequeueInterval: requeueInterval,
 		Retries:         int64(retries),
+		Events:          mgr.GetEventRecorderFor("overwhelm"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)

--- a/scripts/helm-charts/update.go
+++ b/scripts/helm-charts/update.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+func main() {
+	d, err := os.ReadFile(".charts/tmp.yaml")
+	if err != nil {
+		panic(err)
+	}
+	data := string(d)
+	data = strings.ReplaceAll(data, "{{", "\\{\\{")
+	data = strings.ReplaceAll(data, "<GOTEMPLATE>", "{{")
+	data = strings.ReplaceAll(data, "</GOTEMPLATE>", "}}")
+	data = strings.ReplaceAll(data, "{{ toYaml", "\n{{ toYaml")
+	if err = os.WriteFile(".charts/tmp.yaml", []byte(data), 0644); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Create the helm chart folder .charts/overwhelm
- Use Kustomize patches to create the template files with the Values placeholder
- Use the script/helm-charts/update.go script to update the placeholders with go template delimiters and format the resources for helm
- update makefile to add a `make helmManifest` command that creates the resources as a Kustomization, updates the resources for values and finally splits and generates separate template files.
- Updated README accordingly
- Tested locally to install the chart in a Kind cluster
- Added events all across the controller logic so that events can be generated 

### :link: Related Issues
- 
