### PR TITLE
fix:remove the local host address as metrics bind address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ helmManifests: manifests kustomize kubernetes-split-yaml ## Create Helm Template
 
 .PHONY: helmInstall
 helmInstall:
-	helm upgrade -i overwhelm ./.charts/overwhelm
+	helm upgrade -i overwhelm ./charts/overwhelm
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/charts/overwhelm/Chart.yaml
+++ b/charts/overwhelm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: overwhelm
-version: 1.0.1
+version: 1.0.2
 maintainers:
     - name: "Expedia Group"
       url: "https://github.com/ExpediaGroup/overwhelm"

--- a/charts/overwhelm/templates/overwhelm-controller-manager-deployment.yaml
+++ b/charts/overwhelm/templates/overwhelm-controller-manager-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,5 +30,5 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=:8080"
         - "--leader-elect"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
-  The metrics Bind address was set to 127.0.0.1 which wouldnt allow outside communication to scrape metrics. Changed to 0.0.0.0

### :link: Related Issues
- 
