### PR TITLE
Change Chart.yaml version

### DIFF
--- a/charts/overwhelm/Chart.yaml
+++ b/charts/overwhelm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: overwhelm
-version: 1.1.6
+version: 1.2.0
 maintainers:
     - name: "Expedia Group"
       url: "https://github.com/ExpediaGroup/overwhelm"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- The updates done under #31 are not reflected in Chart version `1.1.6`. 
- Downloading https://github.com/ExpediaGroup/overwhelm/releases/download/overwhelm-1.1.6/overwhelm-1.1.6.tgz still has the old role with no create/update permission for events.
Looks like 1.1.6 was used earlier to package the chart. 


### :link: Related Issues
- 
