### PR TITLE
fix: order of conditions to add pod status first and remove it only i…

### DIFF
--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -5,7 +5,7 @@ on:
     branches: [master]
     types: [completed]
 env:
-  VERSION: v0.0.5
+  VERSION: v0.0.6
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -125,12 +125,14 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 		helmReadyStatus, _ := r.reconcileHelmReleaseStatus(ctx, application)
-		if helmReadyStatus && r.reconcilePodStatus(ctx, application, pod) {
+		if r.reconcilePodStatus(ctx, application, pod) && helmReadyStatus {
 			if patchErr := r.patchStatus(ctx, application); patchErr != nil {
 				log.Error(patchErr, "Error updating application status")
 				return ctrl.Result{}, patchErr
 			}
+
 		}
+
 		return ctrl.Result{}, nil
 	}
 	if application.ObjectMeta.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
…f the hr status is reconciled

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Fix the order of the pod status and hr status check so that if the hr status is reconciled then pod status is removed. Earlier it was being removed before the pod status was added. 

### :link: Related Issues
- 
