### PR TITLE
Mismatch of conditions

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -244,14 +244,15 @@ func (r *ApplicationReconciler) reconcileHelmReleaseStatus(ctx context.Context, 
 		apimeta.RemoveStatusCondition(&application.Status.Conditions, v1.PodReady)
 		return false, nil
 	}
+	helmReadyStatusNotReconciled := true
 	for _, condition := range hr.GetConditions() {
 		apimeta.SetStatusCondition(&application.Status.Conditions, condition)
 		if condition.Type == meta.ReadyCondition && condition.Reason == v2beta1.ReconciliationSucceededReason {
 			apimeta.RemoveStatusCondition(&application.Status.Conditions, v1.PodReady)
-			return false, nil
+			helmReadyStatusNotReconciled = false
 		}
 	}
-	return true, nil
+	return helmReadyStatusNotReconciled, nil
 }
 
 func (r *ApplicationReconciler) reconcilePodStatus(ctx context.Context, application *v1.Application, pod *corev1.Pod) bool {


### PR DESCRIPTION

### :pencil: Description
The PR fixes early return in the loop of conditions if the Reconciliation succeeded status if found on HRs. All conditions on HR will be on Application object, regardless of their order. 


