### PR TITLE
fix: adapt to the major helm controller upgrade 0.37.2

### DIFF
--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -5,7 +5,7 @@ on:
     branches: [master]
     types: [completed]
 env:
-  VERSION: v0.0.10
+  VERSION: v0.0.11
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -255,8 +255,13 @@ func (r *ApplicationReconciler) reconcileHelmReleaseStatus(ctx context.Context, 
 	}
 	helmReadyStatusNotReconciled := true
 	for _, condition := range hr.GetConditions() {
-		apimeta.SetStatusCondition(&application.Status.Conditions, condition)
-		if condition.Type == meta.ReadyCondition && condition.Reason == v2beta2.ReconciliationSucceededReason {
+		if condition.Reason == meta.ProgressingReason || condition.Status == metav1.ConditionUnknown {
+			v1.AppInProgressStatus(application)
+			break
+		} else {
+			apimeta.SetStatusCondition(&application.Status.Conditions, condition)
+		}
+		if condition.Type == meta.ReadyCondition && condition.Status == metav1.ConditionTrue {
 			apimeta.RemoveStatusCondition(&application.Status.Conditions, v1.PodReady)
 			helmReadyStatusNotReconciled = false
 		}

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -277,15 +277,15 @@ var _ = Describe("Application controller", func() {
 							return k8sClient.Get(ctx, client.ObjectKey{Name: a.Name, Namespace: a.Namespace}, hr)
 						}
 					}(ctx, hr), 5*time.Second, 300*time.Millisecond).Should(BeNil())
-				hr.Status.ObservedGeneration = 1
-				hr.Generation = hr.Status.ObservedGeneration
+				hr.Status.LastAttemptedGeneration = 1
+				hr.Generation = hr.Status.LastAttemptedGeneration
 				conditions := []metav1.Condition{{
 					Type:               meta.ReadyCondition,
 					Status:             metav1.ConditionStatus(v1.ConditionTrue),
 					ObservedGeneration: 1,
 					LastTransitionTime: metav1.NewTime(time.Now()),
-					Message:            "Helm Release Reconciled",
-					Reason:             meta.SucceededReason,
+					Message:            "Helm Release Reconciliation in Progress",
+					Reason:             meta.ProgressingReason,
 				}}
 				hr.SetConditions(conditions)
 				Expect(k8sClient.Status().Update(ctx, hr)).Should(BeNil())


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ X] Code is up-to-date with the `main` branch.
* [X ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- With the Helm Controller Upgrade, the controller is adding a lot of intermediate statuses which is causing noise in our application object. The upgrade also changed the Ready status reason which the overwhelm was dependant on. This change ensure all the intermediate noise is ignored and only final statuses are recorded. 

### :link: Related Issues
- 
