### PR TITLE
fix: buildx requires setup before using it

### DIFF
--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -25,13 +25,19 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
+      
       - uses: actions/checkout@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3.0.0
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,18 +11,25 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.17
+      
       - uses: actions/checkout@v3
+      
       - name: Log in to the Container registry
         uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4.0.1
         with:
           images: ghcr.io/${{ github.repository }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
       - name: Build and push Docker image
         uses: docker/build-push-action@v3.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Multiarch builds needs a build machine setup which then builds multiple architectures
- Also updated go version to 1.24

### :link: Related Issues
- 
